### PR TITLE
CORE-4374: Add packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=build /neard /usr/local/bin/neard
 
 RUN chown -R near:near /home/near
 
+RUN apt-get update -y && apt-get install curl xz-utils -y
+
 USER near
 
 ENTRYPOINT ["neard"]


### PR DESCRIPTION
We need curl and xz package in the image, because NEAR testnet init is not working and we need to download and unpack archive with genesis manually