### PR TITLE
Bump mainnet version to 1.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=1.29.0-rc.1
+ENV VERSION=1.28.1
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
NEAR using different versions for mainnet and testnet so we creating 1.28.1 release