### PR TITLE
feat/near-v1.36.4 - Bumps Near version to v1.36.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=1.36.2
+ENV VERSION=1.36.4
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
## Reason
Security fix on v1.36.4. Upgrade enforced!
[**Changelog**](https://github.com/near/nearcore/releases/tag/1.36.4)

## Tested
Image available at [**moraesjeremias/near-node:1.36-4**](https://hub.docker.com/layers/moraesjeremias/near-node/1.36.4/images/sha256-c74f0b1f5a5fef135decf5aaa1e64a2cd129eae46209c790f953e94ff8f7ccec?context=explore)