### PR TITLE
feat: Bumps near to v1.37.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=1.36.5
+ENV VERSION=1.37.1
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
**Hey sweeties, find one more friendly contribution. Stay safe :) **

## Description
- [x] Bumps near to v1.37.1

## Changelog
[v1.37.1](https://github.com/near/nearcore/releases/tag/1.37.1)

## Motivation and Context
Blockchain Upgrades

## How Has This Been Tested?
```docker
╰─$ docker build -t moraesjeremias/near:v1.37.1 .
[+] Building 1.6s (17/17) FINISHED
 => => naming to docker.io/moraesjeremias/near:v1.37.1 
```

[moraesjeremias/near:v1.37.1](https://hub.docker.com/layers/moraesjeremias/near/v1.37.1/images/sha256-aad7d8c49bf67cf0879900299c64bb69d57bf0e197edf8587b3f94476b51639c?context=explore)

## Screenshots (if appropriate)
