### PR TITLE
Bump up to v2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=2.4.0
+ENV VERSION=2.5.0
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
```
CODE_COLOR: CODE_YELLOW_MAINNET
RELEASE_VERSION: 2.5.0
PROTOCOL_UPGRADE: TRUE
DATABASE_UPGRADE: FALSE
SECURITY_UPGRADE: FALSE
```
Details: 
https://github.com/near/nearcore/releases/tag/2.5.0