### PR TITLE
v2.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=2.5.2
+ENV VERSION=2.6.0
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
```
CODE_COLOR: CODE_YELLOW_MAINNET
RELEASE_VERSION: 2.6.0
PROTOCOL_UPGRADE: TRUE
DATABASE_UPGRADE: TRUE
SECURITY_UPGRADE: FALSE
```

https://github.com/near/nearcore/releases/tag/2.6.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application to use version 2.6.0 of the core software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->