### PR TITLE
Bump to v2.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=2.6.1
+ENV VERSION=2.6.2
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
https://github.com/near/nearcore/releases/tag/2.6.2

```
CODE_COLOR: CODE_GREEN_MAINNET
RELEASE_VERSION: 2.6.2
PROTOCOL_UPGRADE: FALSE
DATABASE_UPGRADE: FALSE
SECURITY_UPGRADE: FALSE
```

## Non-protocol Changes

Enabled TCP_NODELAY on all peer connections to reduce latency. Improves chunk endorsement rate for validators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application to use version 2.6.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->