### PR TITLE
v2.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.62.0-bullseye as build
 
-ENV VERSION=2.6.2
+ENV VERSION=2.6.3
 
 
 RUN apt-get update -y && apt-get install git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \


### PR DESCRIPTION
```
CODE_COLOR: CODE_GREEN_MAINNET
RELEASE_VERSION: 2.6.3
PROTOCOL_UPGRADE: FALSE
DATABASE_UPGRADE: FALSE
SECURITY_UPGRADE: FALSE
```

## Non-protocol Changes

Allow chunk-only validators (outside the top 100 validators, not chunk producers) to join the Tier 1 network. This reduces latency of messages sent and received by chunk validators and improves the chunk endorsement rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application to use version 2.6.3 of nearcore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->